### PR TITLE
Add: Added default PQ secure Kex and Keyalgorithms for docker

### DIFF
--- a/docker/ssh_config
+++ b/docker/ssh_config
@@ -22,13 +22,13 @@
 ###############################################################################
 
 # Key-exchange algorithms
-KexAlgorithms ecdh-nistp384-kyber-768r3-sha384-d00@openquantumsafe.org
+KexAlgorithms bike-l1-sha512,bike-l3-sha512,classic-mceliece-348864-sha256,classic-mceliece-348864f-sha256,classic-mceliece-460896-sha512,classic-mceliece-460896f-sha512,classic-mceliece-6688128-sha512,classic-mceliece-6688128f-sha512,classic-mceliece-6960119-sha512,classic-mceliece-6960119f-sha512,classic-mceliece-8192128-sha512,classic-mceliece-8192128f-sha512,frodokem-640-aes-sha256,frodokem-976-aes-sha384,frodokem-1344-aes-sha512,frodokem-640-shake-sha256,frodokem-976-shake-sha384,frodokem-1344-shake-sha512,hqc-128-sha256,hqc-192-sha384,hqc-256-sha512,kyber-512-sha256,kyber-768-sha384,kyber-1024-sha512
 
 # The host key algorithms ssh accepts
-HostKeyAlgorithms ssh-ecdsa-nistp384-dilithium3
+HostKeyAlgorithms ssh-dilithium2,ssh-dilithium3,ssh-dilithium5,ssh-falcon512,ssh-falcon1024,ssh-sphincssha2128fsimple,ssh-sphincssha2256fsimple
 
 # The algorithms used for public key authentication
-PubkeyAcceptedKeyTypes ssh-ecdsa-nistp384-dilithium3
+PubkeyAcceptedKeyTypes ssh-dilithium2,ssh-dilithium3,ssh-dilithium5,ssh-falcon512,ssh-falcon1024,ssh-sphincssha2128fsimple,ssh-sphincssha2256fsimple
 
 # Define how unknown host keys should be handled
 #StrictHostKeyChecking ask
@@ -45,10 +45,17 @@ Port 2222
 
 #IdentityFile ~/.ssh/id_ssh-falcon512
 
-IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-dilithium3
+#IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-dilithium3
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-falcon512
 
 #IdentityFile ~/.ssh/id_ssh-rsa3072-falcon512
+IdentityFile ~/.ssh/id_ssh-dilithium2
+IdentityFile ~/.ssh/id_ssh-dilithium3
+IdentityFile ~/.ssh/id_ssh-dilithium5
+IdentityFile ~/.ssh/id_ssh-falcon512
+IdentityFile ~/.ssh/id_ssh-falcon1024
+IdentityFile ~/.ssh/id_ssh-sphincssha2128fsimple
+IdentityFile ~/.ssh/id_ssh-sphincssha2256fsimple
 
 ###############################################################################
 #-- Settings for CLASSICAL SSH ------------------------------------------------

--- a/docker/sshd_config
+++ b/docker/sshd_config
@@ -15,13 +15,13 @@
 ###############################################################################
 
 # Key-exchange algorithms
-KexAlgorithms ecdh-nistp384-kyber-768r3-sha384-d00@openquantumsafe.org
+KexAlgorithms bike-l1-sha512,bike-l3-sha512,classic-mceliece-348864-sha256,classic-mceliece-348864f-sha256,classic-mceliece-460896-sha512,classic-mceliece-460896f-sha512,classic-mceliece-6688128-sha512,classic-mceliece-6688128f-sha512,classic-mceliece-6960119-sha512,classic-mceliece-6960119f-sha512,classic-mceliece-8192128-sha512,classic-mceliece-8192128f-sha512,frodokem-640-aes-sha256,frodokem-976-aes-sha384,frodokem-1344-aes-sha512,frodokem-640-shake-sha256,frodokem-976-shake-sha384,frodokem-1344-shake-sha512,hqc-128-sha256,hqc-192-sha384,hqc-256-sha512,kyber-512-sha256,kyber-768-sha384,kyber-1024-sha512
 
 # Host key algorithms, these determine the generated host keys
-HostKeyAlgorithms ssh-ecdsa-nistp384-dilithium3
+HostKeyAlgorithms ssh-dilithium2,ssh-dilithium3,ssh-dilithium5,ssh-falcon512,ssh-falcon1024,ssh-sphincssha2128fsimple,ssh-sphincssha2256fsimple
 
 # Those determine the accepted public keys for public key authentication
-PubkeyAcceptedKeyTypes ssh-ecdsa-nistp384-dilithium3
+PubkeyAcceptedKeyTypes ssh-dilithium2,ssh-dilithium3,ssh-dilithium5,ssh-falcon512,ssh-falcon1024,ssh-sphincssha2128fsimple,ssh-sphincssha2256fsimple
 
 # The port sshd is listening on
 Port 2222
@@ -35,10 +35,17 @@ Port 2222
 
 #HostKey /opt/oqs-ssh/ssh_host_ssh-falcon512_key
 
-HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp384-dilithium3_key
+#HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp384-dilithium3_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp256-falcon512_key
 
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-falcon512_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-dilithium2_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-dilithium3_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-dilithium5_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-falcon512_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-falcon1024_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-sphincssha2128fsimple_key
+HostKey /opt/oqs-ssh/ssh_host_ssh-sphincssha2256fsimple_key
 
 
 ###############################################################################


### PR DESCRIPTION
# Description
- Enables the default PQ secure algorithms that have are default enabled from liboqs
- Enables algorithms on Server and Client side